### PR TITLE
Feature Libsignal

### DIFF
--- a/Example/example.ts
+++ b/Example/example.ts
@@ -177,8 +177,10 @@ const startSock = async() => {
 								const phone = msg.key.remoteJid!.split('@')[0];
 								const lidUser = await sock.onWhatsApp(phone);
 								console.log('latest id is', lidUser, 'and my lid is', lid);
-								await sock!.readMessages([msg.key])
-								await sendMessageWTyping({ text: `Seu lid: ${JSON.stringify(lidUser[0])}\nMeu lid: ${JSON.stringify(lid)}` }, msg.key.remoteJid!)
+								await sock!.readMessages([msg.key]);
+								const dados = typeof lidUser[0].lid === 'string' ? lidUser[0].lid : msg.key.remoteJid!;
+								console.log(`dados ${dados}`);
+								await sendMessageWTyping({ text: `Enviado pelo ${dados}\n\nSeu lid: ${JSON.stringify(lidUser[0])}\nMeu lid: ${JSON.stringify(lid)}` }, dados);
 							}
 						}
 					}

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -40,7 +40,7 @@ import {
 	getBinaryNodeChildBuffer,
 	getBinaryNodeChildren,
 	isJidGroup, isJidStatusBroadcast,
-	isJidUser,
+	isUserIdentifier,
 	jidDecode,
 	jidEncode,
 	jidNormalizedUser,
@@ -903,7 +903,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							} else if(msg.key.fromMe) { // message was sent by us from a different device
 								type = 'sender'
 								// need to specially handle this case
-								if(isJidUser(msg.key.remoteJid!)) {
+								if(isUserIdentifier(msg.key.remoteJid!)) {
 									participant = author
 								}
 							} else if(!sendActiveReceipts) {

--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -9,7 +9,7 @@ import { AnyMessageContent, MediaConnInfo, MessageReceiptType, MessageRelayOptio
 import { aggregateMessageKeysNotFromMe, assertMediaContent, bindWaitForEvent, decryptMediaRetryData, encodeSignedDeviceIdentity, encodeWAMessage, encryptMediaRetryRequest, extractDeviceJids, generateMessageIDV2, generateWAMessage, getContentType, getStatusCodeForMediaRetry, getUrlFromDirectPath, getWAUploadToServer, normalizeMessageContent, parseAndInjectE2ESessions, unixTimestampSeconds } from '../Utils'
 import { getWhatsAppDomain, isLidIdentifier } from '../Utils/lid-utils'
 import { getUrlInfo } from '../Utils/link-preview'
-import { areJidsSameUser, BinaryNode, BinaryNodeAttributes, getBinaryNodeChild, getBinaryNodeChildren, isJidGroup, isJidUser, jidDecode, jidEncode, jidNormalizedUser, JidWithDevice } from '../WABinary'
+import { areJidsSameUser, BinaryNode, BinaryNodeAttributes, getBinaryNodeChild, getBinaryNodeChildren, isJidGroup, isUserIdentifier, jidDecode, jidEncode, jidNormalizedUser, JidWithDevice } from '../WABinary'
 import { USyncQuery, USyncUser } from '../WAUSync'
 import { makeGroupsSocket } from './groups'
 import ListType = proto.Message.ListMessage.ListType;
@@ -92,7 +92,7 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 			node.attrs.t = unixTimestampSeconds().toString()
 		}
 
-		if(type === 'sender' && isJidUser(jid)) {
+		if(type === 'sender' && isUserIdentifier(jid)) {
 			node.attrs.recipient = jid
 			node.attrs.to = participant!
 		} else {

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -34,10 +34,6 @@ export type SocketConfig = {
     defaultQueryTimeoutMs: number | undefined
     /** ping-pong interval for WS connection */
     keepAliveIntervalMs: number
-	/** should baileys use the mobile api instead of the multi device api
-     * @deprecated This feature has been removed
-    */
-	mobile?: boolean
     /** proxy agent */
     agent?: Agent
     /** logger */
@@ -48,10 +44,6 @@ export type SocketConfig = {
     browser: WABrowserDescription
     /** agent used for fetch requests -- uploading/downloading media */
     fetchAgent?: Agent
-    /** should the QR be printed in the terminal
-    * @deprecated This feature has been removed
-    */
-    printQRInTerminal?: boolean
     /** should events be emitted for actions done by this socket connection */
     emitOwnEvents: boolean
     /** custom upload hosts to upload media to */

--- a/src/Utils/decode-wa-message.ts
+++ b/src/Utils/decode-wa-message.ts
@@ -1,7 +1,7 @@
 import { Boom } from '@hapi/boom'
 import { waproto as proto } from '../../WAProto'
 import { SignalRepository, WAMessageKey } from '../Types'
-import { areJidsSameUser, BinaryNode, isJidBroadcast, isJidGroup, isJidNewsletter, isJidStatusBroadcast, isJidUser, isLidUser } from '../WABinary'
+import { areJidsSameUser, BinaryNode, isJidBroadcast, isJidGroup, isJidNewsletter, isJidStatusBroadcast, isLidUser, isUserIdentifier } from '../WABinary'
 import { unpadRandomMax16 } from './generics'
 import { ILogger } from './logger'
 
@@ -47,7 +47,7 @@ export function decodeMessageNode(
 	const isMe = (jid: string) => areJidsSameUser(jid, meId)
 	const isMeLid = (jid: string) => areJidsSameUser(jid, meLid)
 
-	if(isJidUser(from)) {
+	if(isUserIdentifier(from)) {
 		if(recipient) {
 			if(!isMe(from)) {
 				throw new Boom('receipient present, but msg not from me', { data: stanza })
@@ -180,7 +180,7 @@ export const decryptMessageNode = (
 							break
 						case 'pkmsg':
 						case 'msg':
-							const user = isJidUser(sender) ? sender : author
+							const user = isUserIdentifier(sender) ? sender : author
 							msgBuffer = await repository.decryptMessage({
 								jid: user,
 								type: e2eType,

--- a/src/Utils/lid-utils.ts
+++ b/src/Utils/lid-utils.ts
@@ -1,0 +1,69 @@
+import { S_WHATSAPP_NET } from '../WABinary'
+
+/**
+ * Utility functions for handling LID (Local Identifier) vs JID (Jabber ID) in WhatsApp
+ *
+ * LID format: number@lid (e.g., 188480915300534@lid)
+ * JID format: number@s.whatsapp.net (e.g., 5521987908324@s.whatsapp.net)
+ */
+
+/**
+ * Determine the correct WhatsApp domain based on whether to use LID or JID
+ * @param useLid - Whether to use LID format (true) or JID format (false)
+ * @returns The appropriate domain string
+ */
+export const getWhatsAppDomain = (useLid: boolean): string => {
+	return useLid ? 'lid' : S_WHATSAPP_NET
+}
+
+/**
+ * Detect if an identifier is in LID format
+ * @param identifier - The identifier to check (optional)
+ * @returns True if the identifier contains '@lid', false otherwise
+ */
+export const isLidIdentifier = (identifier?: string): boolean => {
+	return identifier ? identifier.includes('@lid') : false
+}
+
+/**
+ * Extract the domain from an identifier
+ * @param identifier - The identifier (JID or LID)
+ * @returns The domain part (e.g., 'lid', 's.whatsapp.net')
+ */
+export const getIdentifierDomain = (identifier: string): string => {
+	const parts = identifier.split('@')
+	return parts.length > 1 ? parts[1] : ''
+}
+
+/**
+ * Get the identifier type based on the identifier string
+ * @param identifier - The identifier to analyze
+ * @returns 'lid' or 'jid' based on the identifier format
+ */
+export const getIdentifierType = (identifier: string): 'lid' | 'jid' => {
+	return isLidIdentifier(identifier) ? 'lid' : 'jid'
+}
+
+/**
+ * Automatically determine if LID should be used based on an identifier
+ * @param identifier - The identifier to analyze (optional)
+ * @returns True if the identifier suggests LID usage
+ */
+export const shouldUseLid = (identifier?: string): boolean => {
+	return identifier ? isLidIdentifier(identifier) : false
+}
+
+/**
+ * Format an identifier with the appropriate domain
+ * @param user - The user part (number)
+ * @param type - Whether to format as 'lid' or 'jid'
+ * @param device - Device number (for JID format, optional)
+ * @returns Properly formatted identifier
+ */
+export const formatIdentifier = (user: string, type: 'lid' | 'jid', device = 0): string => {
+	if(type === 'lid') {
+		return `${user}@lid`
+	} else {
+		return device === 0 ? `${user}@${S_WHATSAPP_NET}` : `${user}.${device}@${S_WHATSAPP_NET}`
+	}
+}

--- a/src/WABinary/jid-utils.ts
+++ b/src/WABinary/jid-utils.ts
@@ -72,3 +72,12 @@ export const jidNormalizedUser = (jid: string | undefined) => {
 	const { user, server } = result
 	return jidEncode(user, server === 'c.us' ? 's.whatsapp.net' : server as JidServer)
 }
+
+/**
+ * Check if a JID represents a user (either traditional JID or LID format)
+ * @param jid - The identifier to check
+ * @returns True if the JID represents a user (LID or traditional JID)
+ */
+export const isUserIdentifier = (jid: string | undefined): boolean => {
+	return !!(isJidUser(jid) || isLidUser(jid))
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce comprehensive LID identifier support by abstracting domain logic into a new utility module, extending nearly all socket and signal methods to handle a `useLid` flag (with auto-detection), and refactoring domain routing away from hard-coded values. Also clean up deprecated options and refine the example usage script.

New Features:
- Add support for LID (Local Identifier) format alongside standard JID by introducing dynamic domain routing based on a `useLid` flag.
- Provide a new `lid-utils` module with helper functions (`getWhatsAppDomain`, `isLidIdentifier`, `formatIdentifier`, etc.) to handle LID vs JID logic.

Enhancements:
- Extend core socket methods (privacy settings, profile updates, blocklist, business catalog, message sending/receiving, app state sync, etc.) to accept a `useLid` parameter and provide auto-detect variants for convenience.
- Replace direct references to the fixed WhatsApp domain (S_WHATSAPP_NET) with dynamic calls to `getWhatsAppDomain` for all IQ queries and keep-alive requests.
- Refactor signal utilities to parse and format identifiers via `parseIdentifier`, handle sessions more robustly, and clean up corrupted sessions automatically.

Chores:
- Remove deprecated `printQRInTerminal` and mobile API code paths from the example and socket initialization.
- Update example script to silence logs by default and output QR codes as URLs for browser opening.